### PR TITLE
chore: release v0.1.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jenkins"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jenkins"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 # crates.io
 authors = ["Kairyou"]

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -115,8 +115,23 @@ cargo clippy --all-targets --all-features -- -D warnings # --fix --allow-dirty
 # cargo doc --no-deps # Generate documentation
 # python3 -m http.server 8000 -d ./target/doc/jenkins/ # Preview documentation
 
-# cargo install cargo-release
-cargo release patch --execute --no-publish # auto update version and push tag to remote
+# Install once: cargo install cargo-release
+# Preview the next patch release without changing files or Git history.
+# cargo release patch
+# Run the checks before creating the release commit and tag.
+cargo test --locked --all-targets --all-features
+cargo fmt -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo package --locked
+# Prepare a release branch. The version commit goes through a pull request;
+# create and push the tag only after the pull request is merged.
+git switch -c release/v0.1.31
+cargo release patch --execute --no-publish --no-tag --no-push
+git push -u origin release/v0.1.31
+# After merging the pull request:
+# git switch main && git pull --ff-only
+# git tag -a v0.1.31 -m "Release jenkins version 0.1.31"
+# git push origin v0.1.31
 # publish to cargo.io
 # cargo login
 cargo publish # publish to crates.io


### PR DESCRIPTION
## Release v0.1.31

- Upgrade Rust dependencies and pinned GitHub Actions
- Add TOML history round-trip regression coverage
- Harden release and CI workflow maintenance
- Update the documented release process for `cargo-release`

## Validation

- `cargo test --locked --all-targets --all-features`
- `cargo fmt -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo package --locked`

After this PR is merged, create and push `v0.1.31` from the updated `main` branch to trigger the Release workflow.
