### PR TITLE
docs: add changelog for v0.1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## [Unreleased]
+
+### Added
+
+- Reserved section for upcoming changes.
+
+## [0.1.31] - 2026-08-26
+
+### Added
+
+- TOML history round-trip coverage for Unicode, quotes, backslashes, newlines, and special characters.
+- Rust security auditing, dependency review, CodeQL analysis, and pinned GitHub Actions checks.
+
+### Changed
+
+- Upgraded `base64` to 0.23.1.
+- Upgraded `dirs` to 6.0.0.
+- Upgraded `colored` to 3.1.1.
+- Upgraded `toml` to 1.1.4 and `toml_edit` to 0.25.13.
+- Updated the cross-platform release workflow and its artifact/release actions.
+- Documented the pull-request-based `cargo-release` workflow.
+
+### Fixed
+
+- Corrected the release workflow job name from `release-corss` to `release-cross`.
+
+## [0.1.30] - 2026-08-25
+
+- Previous release. See the [GitHub release](https://github.com/kairyou/jenkins-cli/releases/tag/v0.1.30) for details.
+
+[Unreleased]: https://github.com/kairyou/jenkins-cli/compare/v0.1.31...HEAD
+[0.1.31]: https://github.com/kairyou/jenkins-cli/compare/v0.1.30...v0.1.31
+[0.1.30]: https://github.com/kairyou/jenkins-cli/releases/tag/v0.1.30


### PR DESCRIPTION
## Summary

- Add a repository-level `CHANGELOG.md`
- Document the v0.1.31 dependency, security, CI, TOML, and release workflow changes
- Add an `Unreleased` section and comparison links for future releases

This intentionally does not modify the already published `v0.1.31` tag or release assets.
