### PR TITLE
ci: automate release PR and crates.io publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
           components: clippy, rustfmt
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - name: Check formatting
         run: cargo fmt -- --check
 
@@ -44,4 +44,6 @@ jobs:
         with:
           toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
       - name: Run tests
-        run: cargo test -v --no-fail-fast
+        run: cargo test --locked --all-targets --all-features
+      - name: Verify package
+        run: cargo package --locked

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,150 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Semantic version bump"
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      auto_merge:
+        description: "Enable auto-merge after required checks pass"
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          # A GitHub App or fine-grained PAT makes CI run normally on the
+          # generated PR. Without it, GitHub may require manual workflow approval.
+          token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+
+      - name: Read Rust toolchain
+        id: rust-toolchain
+        run: echo "toolchain=$(grep '^channel =' rust-toolchain.toml | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
+
+      - name: Install cargo-release
+        run: cargo install cargo-release --version 1.1.4 --locked
+
+      - name: Resolve next version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+
+          current="$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "jenkins") | .version')"
+          IFS=. read -r major minor patch <<< "${current}"
+
+          case "${BUMP}" in
+            patch) next="${major}.${minor}.$((patch + 1))" ;;
+            minor) next="${major}.$((minor + 1)).0" ;;
+            major) next="$((major + 1)).0.0" ;;
+            *) echo "Unsupported bump: ${BUMP}" >&2; exit 1 ;;
+          esac
+
+          branch="release/v${next}"
+          if git ls-remote --exit-code --heads origin "refs/heads/${branch}" >/dev/null 2>&1; then
+            exists=true
+          else
+            exists=false
+          fi
+
+          echo "current=${current}" >> "$GITHUB_OUTPUT"
+          echo "next=${next}" >> "$GITHUB_OUTPUT"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+          echo "exists=${exists}" >> "$GITHUB_OUTPUT"
+
+      - name: Create version commit
+        env:
+          BUMP: ${{ inputs.bump }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          BRANCH_EXISTS: ${{ steps.version.outputs.exists }}
+          EXPECTED_VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          set -euo pipefail
+
+          if [ "${BRANCH_EXISTS}" = "true" ]; then
+            git fetch origin "${BRANCH}"
+            git switch -c "${BRANCH}" --track "origin/${BRANCH}"
+          else
+            git switch -c "${BRANCH}"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            cargo release "${BUMP}" \
+              --execute \
+              --no-confirm \
+              --no-publish \
+              --no-tag \
+              --no-push
+          fi
+
+          actual="$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "jenkins") | .version')"
+          if [ "${actual}" != "${EXPECTED_VERSION}" ]; then
+            echo "Expected version ${EXPECTED_VERSION}, cargo-release produced ${actual}" >&2
+            exit 1
+          fi
+
+          if [ "${BRANCH_EXISTS}" = "false" ]; then
+            git push --set-upstream origin "${BRANCH}"
+          fi
+
+      - name: Open release pull request
+        id: pull-request
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          set -euo pipefail
+
+          url="$(gh pr list --base main --head "${BRANCH}" --state open --json url --jq '.[0].url')"
+          if [ -z "${url}" ]; then
+            url="$(gh pr create \
+              --base main \
+              --head "${BRANCH}" \
+              --title "chore: release v${VERSION}" \
+              --body "Automated release preparation for \`v${VERSION}\`. Merge this pull request to publish the crate and create the GitHub release.")"
+          fi
+
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          echo "Created ${url}"
+
+      - name: Enable auto-merge
+        if: ${{ inputs.auto_merge }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          PR_URL: ${{ steps.pull-request.outputs.url }}
+        run: gh pr merge "${PR_URL}" --auto --squash
+
+      - name: Add summary
+        env:
+          PR_URL: ${{ steps.pull-request.outputs.url }}
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          echo "## Release v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Created release pull request: ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:
@@ -14,13 +16,183 @@ on:
         options:
           - edgeone_release
           - prerelease
+          - repair_release
+      release_tag:
+        description: "Existing v* tag to repair (repair_release mode only)"
+        type: string
+        required: false
 
 permissions:
   contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.release.outputs.build }}
+      formal: ${{ steps.release.outputs.formal }}
+      publish: ${{ steps.release.outputs.publish }}
+      release_sha: ${{ steps.release.outputs.release_sha }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve release
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_SHA: ${{ github.sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          echo "build=false" >> "$GITHUB_OUTPUT"
+          echo "formal=false" >> "$GITHUB_OUTPUT"
+          echo "publish=false" >> "$GITHUB_OUTPUT"
+          echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=" >> "$GITHUB_OUTPUT"
+          echo "version=" >> "$GITHUB_OUTPUT"
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${INPUT_MODE}" = "prerelease" ]; then
+              echo "build=true" >> "$GITHUB_OUTPUT"
+              echo "release_tag=prerelease" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if [ "${INPUT_MODE}" = "repair_release" ]; then
+              if [[ ! "${INPUT_RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "repair_release requires release_tag in vX.Y.Z format." >&2
+                exit 1
+              fi
+
+              release_sha="$(git rev-parse "${INPUT_RELEASE_TAG}^{commit}")"
+              git checkout --detach "${release_sha}"
+              version="$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "jenkins") | .version')"
+              if [ "${INPUT_RELEASE_TAG}" != "v${version}" ]; then
+                echo "${INPUT_RELEASE_TAG} contains Cargo version ${version}." >&2
+                exit 1
+              fi
+
+              status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+                --header 'User-Agent: jenkins-cli-release (github.com/kairyou/jenkins-cli)' \
+                "https://crates.io/api/v1/crates/jenkins/${version}")"
+              case "${status}" in
+                200) publish=false ;;
+                404) publish=true ;;
+                *) echo "crates.io returned HTTP ${status}" >&2; exit 1 ;;
+              esac
+
+              echo "build=true" >> "$GITHUB_OUTPUT"
+              echo "formal=true" >> "$GITHUB_OUTPUT"
+              echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+              echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
+              echo "release_tag=${INPUT_RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+              echo "version=${version}" >> "$GITHUB_OUTPUT"
+              echo "Repairing ${INPUT_RELEASE_TAG} from ${release_sha} (publish=${publish})."
+              exit 0
+            fi
+
+            exit 0
+          fi
+
+          if [ "${REF_TYPE}" = "tag" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            echo "release_tag=${REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A push to main is only a formal-release trigger when its commit is
+          # associated with a merged release PR created from this repository.
+          # Ordinary contributor PRs and direct pushes stop here, even if they
+          # accidentally edit Cargo.toml's version.
+          pull_requests="$(GH_TOKEN="${GITHUB_TOKEN}" gh api \
+            --header 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/pulls")"
+          release_pr="$(jq -r --arg repository "${GITHUB_REPOSITORY}" '
+            [.[] | select(
+              .merged_at != null and
+              .base.ref == "main" and
+              .head.repo.full_name == $repository and
+              (.head.ref | startswith("release/v"))
+            )] |
+            first |
+            if . == null then empty else [.head.ref, .title] | @tsv end
+          ' <<< "${pull_requests}")"
+
+          if [ -z "${release_pr}" ]; then
+            echo "${RELEASE_SHA} is not the result of an in-repository release PR; skipping."
+            exit 0
+          fi
+
+          release_branch="${release_pr%%$'\t'*}"
+          release_title="${release_pr#*$'\t'}"
+          version="$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "jenkins") | .version')"
+          tag="v${version}"
+          expected_branch="release/${tag}"
+          expected_title="chore: release ${tag}"
+
+          if [ "${release_branch}" != "${expected_branch}" ] || [ "${release_title}" != "${expected_title}" ]; then
+            echo "Release PR identity does not match Cargo version ${version}." >&2
+            echo "Expected branch/title: ${expected_branch} / ${expected_title}" >&2
+            echo "Actual branch/title:   ${release_branch} / ${release_title}" >&2
+            exit 1
+          fi
+
+          # An existing immutable tag means this version has already passed the
+          # formal release boundary. This also keeps historical tagged versions
+          # from being republished if they were never uploaded to crates.io.
+          if git rev-parse --verify --quiet "${tag}^{commit}" >/dev/null; then
+            tagged_sha="$(git rev-parse "${tag}^{commit}")"
+            if [ "${RUN_ATTEMPT}" -gt 1 ] && [ "${tagged_sha}" = "${RELEASE_SHA}" ]; then
+              echo "Retrying ${tag} from its original release commit."
+              echo "build=true" >> "$GITHUB_OUTPUT"
+              echo "formal=true" >> "$GITHUB_OUTPUT"
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "release_tag=${tag}" >> "$GITHUB_OUTPUT"
+              echo "version=${version}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "${tag} already exists at ${tagged_sha}; no formal release is pending."
+            exit 0
+          fi
+
+          status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            --header 'User-Agent: jenkins-cli-release (github.com/kairyou/jenkins-cli)' \
+            "https://crates.io/api/v1/crates/jenkins/${version}")"
+
+          case "${status}" in
+            200) publish=false ;;
+            404) publish=true ;;
+            *) echo "crates.io returned HTTP ${status}" >&2; exit 1 ;;
+          esac
+
+          echo "build=true" >> "$GITHUB_OUTPUT"
+          echo "formal=true" >> "$GITHUB_OUTPUT"
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Preparing ${tag} from ${RELEASE_SHA} (publish=${publish})."
+
   release-cross:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'prerelease' }}
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.build == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,6 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
           persist-credentials: false
       - name: Read Rust toolchain
         id: rust-toolchain
@@ -44,7 +217,7 @@ jobs:
       - name: install cross
         run: cargo install cross --version 0.2.5 --locked
       - name: Build
-        run: cross build --release --target=${{ matrix.target }}
+        run: cross build --locked --release --target=${{ matrix.target }}
       - name: Package
         run: |
           if [[ "${{ matrix.target }}" == *"-windows-"* ]]; then
@@ -59,7 +232,8 @@ jobs:
           path: jenkins-${{ matrix.target }}.*
 
   release-windows:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'prerelease' }}
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.build == 'true' }}
     runs-on: windows-latest
     strategy:
       matrix:
@@ -68,6 +242,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
           persist-credentials: false
       - name: Read Rust toolchain
         id: rust-toolchain
@@ -78,7 +253,7 @@ jobs:
           toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
           targets: ${{ matrix.target }}
       - name: Build
-        run: cargo build --release --target=${{ matrix.target }}
+        run: cargo build --locked --release --target=${{ matrix.target }}
       - name: Package
         run: tar -czf jenkins-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release jenkins.exe
       - name: Upload
@@ -88,7 +263,8 @@ jobs:
           path: jenkins-${{ matrix.target }}.*
 
   release-apple:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'prerelease' }}
+    needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.build == 'true' }}
     runs-on: macos-latest
     strategy:
       matrix:
@@ -98,6 +274,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
           persist-credentials: false
       - name: Read Rust toolchain
         id: rust-toolchain
@@ -107,7 +284,7 @@ jobs:
           toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
           targets: ${{ matrix.target }}
       - name: Build
-        run: cargo build --release --target=${{ matrix.target }}
+        run: cargo build --locked --release --target=${{ matrix.target }}
       - name: Package
         run: tar -czf jenkins-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release jenkins
       - name: Upload
@@ -128,20 +305,107 @@ jobs:
   #     - name: Build
   #       run: wasm-pack build --target web
 
+  publish-crate:
+    needs: [prepare-release, release-cross, release-windows, release-apple]
+    if: ${{ needs.prepare-release.outputs.build == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          persist-credentials: false
+
+      - name: Read Rust toolchain
+        if: ${{ needs.prepare-release.outputs.publish == 'true' }}
+        id: rust-toolchain
+        run: echo "toolchain=$(grep '^channel =' rust-toolchain.toml | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        if: ${{ needs.prepare-release.outputs.publish == 'true' }}
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
+
+      - name: Publish crate
+        if: ${{ needs.prepare-release.outputs.publish == 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked
+
+      - name: Wait for crates.io index
+        if: ${{ needs.prepare-release.outputs.formal == 'true' }}
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          for attempt in {1..20}; do
+            status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              --header 'User-Agent: jenkins-cli-release (github.com/kairyou/jenkins-cli)' \
+              "https://crates.io/api/v1/crates/jenkins/${VERSION}")"
+            if [ "${status}" = "200" ]; then
+              echo "jenkins ${VERSION} is available on crates.io."
+              exit 0
+            fi
+            echo "Waiting for crates.io to expose jenkins ${VERSION} (attempt ${attempt}/20, HTTP ${status})..."
+            sleep 6
+          done
+
+          echo "jenkins ${VERSION} was not visible on crates.io after two minutes." >&2
+          exit 1
+
+      - name: Create annotated release tag
+        if: ${{ needs.prepare-release.outputs.formal == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha' 2>/dev/null || true)"
+          if [ -n "${existing}" ]; then
+            object_type="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.type')"
+            if [ "${object_type}" = "tag" ]; then
+              peeled="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${existing}" --jq '.object.sha')"
+            else
+              peeled="${existing}"
+            fi
+            if [ "${peeled}" != "${RELEASE_SHA}" ]; then
+              echo "${RELEASE_TAG} already points to ${peeled}, expected ${RELEASE_SHA}." >&2
+              exit 1
+            fi
+            echo "${RELEASE_TAG} already exists."
+            exit 0
+          fi
+
+          tag_object="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/git/tags" \
+            -f tag="${RELEASE_TAG}" \
+            -f message="Release jenkins version ${VERSION}" \
+            -f object="${RELEASE_SHA}" \
+            -f type=commit \
+            --jq '.sha')"
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${RELEASE_TAG}" \
+            -f sha="${tag_object}"
+
   create-release:
-    needs: [release-cross, release-windows, release-apple]
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'prerelease' }}
+    needs: [prepare-release, release-cross, release-windows, release-apple, publish-crate]
+    if: ${{ needs.prepare-release.outputs.build == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Resolve release tag
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.mode }}" = "prerelease" ]; then
+          if [ "${{ needs.prepare-release.outputs.release_tag }}" = "prerelease" ]; then
             TAG="prerelease"
             echo "PRERELEASE=true" >> "$GITHUB_ENV"
           else
-            TAG="${{ github.ref_name }}"
+            TAG="${{ needs.prepare-release.outputs.release_tag }}"
             echo "PRERELEASE=false" >> "$GITHUB_ENV"
           fi
           echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
@@ -249,12 +513,11 @@ jobs:
           path: |
             artifacts/checksums.txt
             artifacts/dist-manifest.json
-      - name: Delete existing release (if needed)
+      - name: Replace mutable prerelease
+        if: ${{ needs.prepare-release.outputs.release_tag == 'prerelease' }}
         run: |
           gh release delete "${RELEASE_TAG}" --yes || true
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.mode }}" = "prerelease" ]; then
-            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" || true
-          fi
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" || true
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         env:
@@ -263,21 +526,22 @@ jobs:
           files: artifacts/*
           generate_release_notes: true
           tag_name: ${{ env.RELEASE_TAG }}
-          target_commitish: ${{ github.sha }}
+          target_commitish: ${{ needs.prepare-release.outputs.release_sha }}
           prerelease: ${{ env.PRERELEASE }}
   # "Settings" > "Actions" > "General"
   # "Workflow permissions" > "Read and write permissions"
 
   deploy-edgeone:
-    needs: create-release
-    if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.mode == 'edgeone_release') || (github.event_name != 'workflow_dispatch' && needs.create-release.result == 'success')) }}
+    needs: [prepare-release, create-release]
+    if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.mode == 'edgeone_release') || ((github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_release') && needs.create-release.result == 'success')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
           persist-credentials: false
       - name: Download artifacts (workflow)
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_release' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,7 @@ on:
         options:
           - edgeone_release
           - prerelease
-          - repair_release
-      release_tag:
-        description: "Existing v* tag to repair (repair_release mode only)"
-        type: string
-        required: false
+          - repair_v0_1_31
 
 permissions:
   contents: read
@@ -51,7 +47,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_MODE: ${{ inputs.mode }}
-          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           REF_NAME: ${{ github.ref_name }}
           REF_TYPE: ${{ github.ref_type }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -74,17 +69,13 @@ jobs:
               exit 0
             fi
 
-            if [ "${INPUT_MODE}" = "repair_release" ]; then
-              if [[ ! "${INPUT_RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                echo "repair_release requires release_tag in vX.Y.Z format." >&2
-                exit 1
-              fi
-
-              release_sha="$(git rev-parse "${INPUT_RELEASE_TAG}^{commit}")"
+            if [ "${INPUT_MODE}" = "repair_v0_1_31" ]; then
+              repair_tag="v0.1.31"
+              release_sha="$(git rev-parse "${repair_tag}^{commit}")"
               git checkout --detach "${release_sha}"
               version="$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "jenkins") | .version')"
-              if [ "${INPUT_RELEASE_TAG}" != "v${version}" ]; then
-                echo "${INPUT_RELEASE_TAG} contains Cargo version ${version}." >&2
+              if [ "${repair_tag}" != "v${version}" ]; then
+                echo "${repair_tag} contains Cargo version ${version}." >&2
                 exit 1
               fi
 
@@ -101,9 +92,9 @@ jobs:
               echo "formal=true" >> "$GITHUB_OUTPUT"
               echo "publish=${publish}" >> "$GITHUB_OUTPUT"
               echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
-              echo "release_tag=${INPUT_RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+              echo "release_tag=${repair_tag}" >> "$GITHUB_OUTPUT"
               echo "version=${version}" >> "$GITHUB_OUTPUT"
-              echo "Repairing ${INPUT_RELEASE_TAG} from ${release_sha} (publish=${publish})."
+              echo "Repairing ${repair_tag} from ${release_sha} (publish=${publish})."
               exit 0
             fi
 
@@ -533,7 +524,7 @@ jobs:
 
   deploy-edgeone:
     needs: [prepare-release, create-release]
-    if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.mode == 'edgeone_release') || ((github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_release') && needs.create-release.result == 'success')) }}
+    if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.mode == 'edgeone_release') || ((github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_v0_1_31') && needs.create-release.result == 'success')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -541,7 +532,7 @@ jobs:
           ref: ${{ needs.prepare-release.outputs.release_sha }}
           persist-credentials: false
       - name: Download artifacts (workflow)
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_release' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_v0_1_31' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,9 +194,17 @@ jobs:
           - aarch64-unknown-linux-gnu # ARM64 Linux (GNU)
           - aarch64-unknown-linux-musl # ARM64 Linux (musl)
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout release commit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode != 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Checkout v0.1.31 repair commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: v0.1.31
           persist-credentials: false
       - name: Read Rust toolchain
         id: rust-toolchain
@@ -231,9 +239,17 @@ jobs:
         target:
           - x86_64-pc-windows-msvc # Windows (MSVC)
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout release commit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode != 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Checkout v0.1.31 repair commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: v0.1.31
           persist-credentials: false
       - name: Read Rust toolchain
         id: rust-toolchain
@@ -263,9 +279,17 @@ jobs:
           - x86_64-apple-darwin # Intel Mac
           - aarch64-apple-darwin # M1/M2 Mac
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout release commit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode != 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Checkout v0.1.31 repair commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: v0.1.31
           persist-credentials: false
       - name: Read Rust toolchain
         id: rust-toolchain
@@ -303,9 +327,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout release commit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode != 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Checkout v0.1.31 repair commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: v0.1.31
           persist-credentials: false
 
       - name: Read Rust toolchain
@@ -527,9 +559,17 @@ jobs:
     if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.mode == 'edgeone_release') || ((github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_v0_1_31') && needs.create-release.result == 'success')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout release commit
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode != 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Checkout v0.1.31 repair commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'repair_v0_1_31' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: v0.1.31
           persist-credentials: false
       - name: Download artifacts (workflow)
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'repair_v0_1_31' }}

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -127,7 +127,7 @@ gh workflow run prepare-release.yml -f bump=patch
 gh workflow run prepare-release.yml -f bump=patch -f auto_merge=true
 
 # Repair an incomplete existing release (do not publish or create v* tags locally).
-gh workflow run release.yml -f mode=repair_release -f release_tag=v0.1.31
+gh workflow run release.yml -f mode=repair_v0_1_31
 ```
 
 ### Test

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -106,7 +106,7 @@ cargo build --target x86_64-unknown-linux-gnu --release # build for linux
 # Analyze binary file size
 # cargo bloat --release --crates # cargo install cargo-bloat
 
-# = Release
+# Checks
 # rustup update stable
 cargo test -v --no-fail-fast # test
 cargo fmt -- --check # Check code formatting
@@ -115,26 +115,19 @@ cargo clippy --all-targets --all-features -- -D warnings # --fix --allow-dirty
 # cargo doc --no-deps # Generate documentation
 # python3 -m http.server 8000 -d ./target/doc/jenkins/ # Preview documentation
 
-# Install once: cargo install cargo-release
-# Preview the next patch release without changing files or Git history.
-# cargo release patch
-# Run the checks before creating the release commit and tag.
-cargo test --locked --all-targets --all-features
-cargo fmt -- --check
-cargo clippy --locked --all-targets --all-features -- -D warnings
-cargo package --locked
-# Prepare a release branch. The version commit goes through a pull request;
-# create and push the tag only after the pull request is merged.
-git switch -c release/v0.1.31
-cargo release patch --execute --no-publish --no-tag --no-push
-git push -u origin release/v0.1.31
-# After merging the pull request:
-# git switch main && git pull --ff-only
-# git tag -a v0.1.31 -m "Release jenkins version 0.1.31"
-# git push origin v0.1.31
-# publish to cargo.io
+# Manual equivalent (reference only; the workflow below replaces these steps).
+# cargo release patch --execute --no-publish
 # cargo login
-cargo publish # publish to crates.io
+# cargo publish
+
+# Release: create a release PR; merging it publishes crates.io, tag and binaries.
+gh workflow run prepare-release.yml -f bump=patch
+
+# Optional: merge automatically after required checks and reviews pass.
+gh workflow run prepare-release.yml -f bump=patch -f auto_merge=true
+
+# Repair an incomplete existing release (do not publish or create v* tags locally).
+gh workflow run release.yml -f mode=repair_release -f release_tag=v0.1.31
 ```
 
 ### Test


### PR DESCRIPTION
## Summary

- add a manual workflow that prepares versioned release pull requests
- gate formal releases to merged in-repository release PRs
- build all release artifacts before publishing to crates.io
- create immutable annotated tags and support idempotent release repair
- run locked CI checks and package verification

## Validation

- cargo test --locked --all-targets --all-features
- cargo fmt -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo package --locked --allow-dirty
- actionlint