### PR TITLE
fix(ci): set repository context for release commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,7 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Resolve release tag
         run: |


### PR DESCRIPTION
## Summary

- provide `GH_REPO` to GitHub CLI release commands
- allow the release job to run without a checked-out Git repository

## Verification

- `git diff --check`
- failure reproduced in release run 32946603894