### PR TITLE
ci: require a dedicated token for release pull requests

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,13 +30,22 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
+      - name: Check release token
+        env:
+          RELEASE_PR_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+        run: |
+          test -n "${RELEASE_PR_TOKEN}" || {
+            echo "RELEASE_PR_TOKEN secret is not configured." >&2
+            echo "Configure a fine-grained PAT scoped to this repository with Contents and Pull requests read/write access." >&2
+            exit 1
+          }
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0
-          # A GitHub App or fine-grained PAT makes CI run normally on the
-          # generated PR. Without it, GitHub may require manual workflow approval.
-          token: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          # Use a non-GITHUB_TOKEN identity so the generated PR triggers CI.
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
 
       - name: Read Rust toolchain
         id: rust-toolchain
@@ -116,7 +125,7 @@ jobs:
       - name: Open release pull request
         id: pull-request
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           BRANCH: ${{ steps.version.outputs.branch }}
           VERSION: ${{ steps.version.outputs.next }}
         run: |
@@ -137,7 +146,7 @@ jobs:
       - name: Enable auto-merge
         if: ${{ inputs.auto_merge }}
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           PR_URL: ${{ steps.pull-request.outputs.url }}
         run: gh pr merge "${PR_URL}" --auto --squash
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -121,6 +121,12 @@ cargo clippy --all-targets --all-features -- -D warnings # --fix --allow-dirty
 # cargo publish
 
 # Release: create a release PR; merging it publishes crates.io, tag and binaries.
+# Configure these repository secrets first:
+# - RELEASE_PR_TOKEN: fine-grained PAT scoped to this repository with Contents
+#   and Pull requests read/write access, so the generated PR runs CI.
+# - CARGO_REGISTRY_TOKEN: crates.io API token for publishing.
+# - EDGEONE_API_TOKEN: EdgeOne API token for deployment.
+# For auto_merge=true, enable Settings > General > Pull Requests > Allow auto-merge.
 gh workflow run prepare-release.yml -f bump=patch
 
 # Optional: merge automatically after required checks and reviews pass.


### PR DESCRIPTION
## Summary

- require `RELEASE_PR_TOKEN` before preparing a release
- use the dedicated token for release branches, pull requests, and auto-merge
- document all release secrets and the auto-merge repository setting

## Verification

- `git diff --check`
- confirmed `RELEASE_PR_TOKEN` is configured
- confirmed repository auto-merge is enabled