### PR TITLE
docs: replace star history charts with Shields badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Cross-platform CLI tool for triggering Jenkins builds. Written in Rust for high performance.
 
+[![GitHub stars](https://img.shields.io/github/stars/kairyou/jenkins-cli?style=flat-square&logo=github&label=Stars)](https://github.com/kairyou/jenkins-cli/stargazers)
+
 [中文文档](README_zh.md)
 
 ## Features
@@ -227,10 +229,6 @@ Note: Keep your API token secure. Do not share it or commit it to version contro
 - [x] Follow downstream Jenkins builds
 - [x] i18n support (fluent)
 - [x] Automatically check for updates
-
-## Stars
-
-[![GitHub stars](https://img.shields.io/github/stars/kairyou/jenkins-cli?style=flat-square&logo=github&label=Stars)](https://github.com/kairyou/jenkins-cli/stargazers)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ Note: Keep your API token secure. Do not share it or commit it to version contro
 - [x] i18n support (fluent)
 - [x] Automatically check for updates
 
-## Stargazers over time
-[![Stargazers over time](https://starchart.cc/kairyou/jenkins-cli.svg?variant=adaptive)](https://starchart.cc/kairyou/jenkins-cli)
+## Stars
+
+[![GitHub stars](https://img.shields.io/github/stars/kairyou/jenkins-cli?style=flat-square&logo=github&label=Stars)](https://github.com/kairyou/jenkins-cli/stargazers)
 
 ## License
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -228,9 +228,9 @@ Jenkins User ID 就是登录 Jenkins 网页界面的用户名。
 - [x] i18n 支持 (fluent)
 - [x] 自动检查更新
 
-## Star 趋势
+## Stars
 
-[![Stargazers over time](https://starchart.cc/kairyou/jenkins-cli.svg?variant=adaptive)](https://starchart.cc/kairyou/jenkins-cli)
+[![GitHub stars](https://img.shields.io/github/stars/kairyou/jenkins-cli?style=flat-square&logo=github&label=Stars)](https://github.com/kairyou/jenkins-cli/stargazers)
 
 ## 许可证
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,6 +2,8 @@
 
 跨平台的Jenkins构建触发工具，采用Rust开发以提供卓越性能。
 
+[![GitHub stars](https://img.shields.io/github/stars/kairyou/jenkins-cli?style=flat-square&logo=github&label=Stars)](https://github.com/kairyou/jenkins-cli/stargazers)
+
 [English](README.md)
 
 ## 特性
@@ -227,10 +229,6 @@ Jenkins User ID 就是登录 Jenkins 网页界面的用户名。
 - [x] 跟踪下游 Jenkins 构建
 - [x] i18n 支持 (fluent)
 - [x] 自动检查更新
-
-## Stars
-
-[![GitHub stars](https://img.shields.io/github/stars/kairyou/jenkins-cli?style=flat-square&logo=github&label=Stars)](https://github.com/kairyou/jenkins-cli/stargazers)
 
 ## 许可证
 


### PR DESCRIPTION
Replace the unavailable star history charts in the English and Chinese READMEs with live Shields.io GitHub stars badges.

The badges require no repository token or additional secret.