### PR TITLE
chore: release v0.1.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jenkins"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jenkins"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2021"
 # crates.io
 authors = ["Kairyou"]


### PR DESCRIPTION
Automated release preparation for `v0.1.32`. Merge this pull request to publish the crate and create the GitHub release.